### PR TITLE
fix code for the path of R logo.jpg

### DIFF
--- a/03-documents.Rmd
+++ b/03-documents.Rmd
@@ -706,7 +706,7 @@ In particular, the `context` elements `label` and `chunk.index` can be used to h
 
 ```{r tidy=FALSE}
 output_source = function(code, context, ...) {
-  logo = file.path(R.home(), "doc/html/logo.jpg")
+  logo = file.path(R.home('doc'), "html/logo.jpg")
   if (context$label == "chunk-one") list(
     rmarkdown::html_notebook_output_code("# R Code"),
     paste("Custom output for chunk:", context$chunk.index),

--- a/03-documents.Rmd
+++ b/03-documents.Rmd
@@ -706,7 +706,7 @@ In particular, the `context` elements `label` and `chunk.index` can be used to h
 
 ```{r tidy=FALSE}
 output_source = function(code, context, ...) {
-  logo = file.path(R.home('doc'), "html/logo.jpg")
+  logo = file.path(R.home("doc"), "html", "logo.jpg")
   if (context$label == "chunk-one") list(
     rmarkdown::html_notebook_output_code("# R Code"),
     paste("Custom output for chunk:", context$chunk.index),


### PR DESCRIPTION
`file.path(R.home(), "doc/html/logo.jpg")` is not portable