### PR TITLE
Add sentence about use_rmarkdown_template

### DIFF
--- a/17-templates.Rmd
+++ b/17-templates.Rmd
@@ -20,7 +20,7 @@ This chapter explains how to create templates and share them within an R package
 
 R Markdown templates should be contained within an R package, which can be easily created from the menu `File -> New Project` in RStudio (choose the project type to be "R Package"). If you are already familiar with creating R packages, you are certainly free to use your own favorite way to create a new package.
 
-Templates are located within the `inst/rmarkdown/templates` directory of a package. This structure can be generated automatically with the [`use_rmarkdown_template()`](https://usethis.r-lib.org/reference/use_rmarkdown_template.html) function from the usethis package. It is possible to contain multiple templates in a single package, with each template stored in a separate sub-directory. As a minimal example, `inst/rmarkdown/templates/my_template` requires the following files:
+Templates are located within the `inst/rmarkdown/templates` directory of a package. This structure can be generated automatically with the [`use_rmarkdown_template()`](https://usethis.r-lib.org/reference/use_rmarkdown_template.html) function from the **usethis** package. It is possible to contain multiple templates in a single package, with each template stored in a separate sub-directory. As a minimal example, `inst/rmarkdown/templates/my_template` requires the following files:
 
 ```markdown
 template.yaml

--- a/17-templates.Rmd
+++ b/17-templates.Rmd
@@ -20,7 +20,7 @@ This chapter explains how to create templates and share them within an R package
 
 R Markdown templates should be contained within an R package, which can be easily created from the menu `File -> New Project` in RStudio (choose the project type to be "R Package"). If you are already familiar with creating R packages, you are certainly free to use your own favorite way to create a new package.
 
-Templates are located within the `inst/rmarkdown/templates` directory of a package. It is possible to contain multiple templates in a single package, with each template stored in a separate sub-directory. As a minimal example, `inst/rmarkdown/templates/my_template` requires the following files:
+Templates are located within the `inst/rmarkdown/templates` directory of a package. This structure can be generated automatically with the [`use_rmarkdown_template()`](https://usethis.r-lib.org/reference/use_rmarkdown_template.html) function from the usethis package. It is possible to contain multiple templates in a single package, with each template stored in a separate sub-directory. As a minimal example, `inst/rmarkdown/templates/my_template` requires the following files:
 
 ```markdown
 template.yaml


### PR DESCRIPTION
I think it would be great to add a sentence about the `usethis::use_rmarkdown_template()` function somewhere in this chapter.  I've added it where it made sense for me and am also happy to expand on this if needed.