### PR TITLE
refer to `rmarkdown::paged_table` instead of rmarkdown::print.paged_df

### DIFF
--- a/03-documents.Rmd
+++ b/03-documents.Rmd
@@ -215,7 +215,7 @@ Table: (\#tab:df-print) The possible values of the `df_print` option for the `ht
 | default  | Call the `print.data.frame` generic method |
 | kable  | Use the `knitr::kable` function |
 | tibble  | Use the `tibble::print.tbl_df` function |
-| paged  |  Use `rmarkdown::print.paged_df` to create a pageable table |
+| paged  |  Use `rmarkdown::paged_table` to create a pageable table |
 
 #### Paged printing
 


### PR DESCRIPTION
1. `rmarkdown::print.paged_df()` is incorrect as it is only a pkg-internal function -> needs 3 dots

2. referring to `rmarkdown::paged_table()` seems more sensible for users as it allows to actually create paged table objects.