### PR TITLE
Remove Bootstrap glyphicons link for icons

### DIFF
--- a/10-website.Rmd
+++ b/10-website.Rmd
@@ -350,7 +350,6 @@ This example demonstrates a number of capabilities of navigation bars:
 
     - [Font Awesome](https://fontawesome.com/icons)
     - [Ionicons](http://ionicons.com/)
-    - [Bootstrap Glyphicons](https://getbootstrap.com/components/)
 
     When referring to an icon, you should use its full name including the icon set prefix (e.g., `fa-github`, `ion-social-twitter`, and `glyphicon-time`).
 

--- a/10-website.Rmd
+++ b/10-website.Rmd
@@ -350,6 +350,7 @@ This example demonstrates a number of capabilities of navigation bars:
 
     - [Font Awesome](https://fontawesome.com/icons)
     - [Ionicons](http://ionicons.com/)
+    - [Bootstrap Glyphicons](https://getbootstrap.com/docs/3.3/components/#glyphicons)
 
     When referring to an icon, you should use its full name including the icon set prefix (e.g., `fa-github`, `ion-social-twitter`, and `glyphicon-time`).
 


### PR DESCRIPTION
Bootstrap glyphicons are no longer available. See Bootstrap's note about this under [components](https://getbootstrap.com/docs/4.3/migration/#components). 