### PR TITLE
update list of default Pandoc Markdown extensions

### DIFF
--- a/03-documents.Rmd
+++ b/03-documents.Rmd
@@ -402,7 +402,6 @@ By default, R Markdown is defined as all Pandoc Markdown extensions with the fol
 
 ```
 +autolink_bare_uris
-+ascii_identifier
 +tex_math_single_backslash
 ```
 


### PR DESCRIPTION
remove `ascii_identifier`[1] since it's no longer enabled by default, cf. https://rmarkdown.rstudio.com/docs/news/index.html#rmarkdown-1-16

[1] correct spelling would have been `ascii_identifiers` (mind the **`s`**) anyway.