### PR TITLE
Remove column width for powerpoint presentations.

### DIFF
--- a/04-presentations.Rmd
+++ b/04-presentations.Rmd
@@ -583,11 +583,11 @@ Please read the section "Producing slide shows with Pandoc" in Pandoc's manual f
 
 ```markdown
 :::::: {.columns}
-::: {.column width="40%"}
+::: {.column}
 Content of the left column.
 :::
 
-::: {.column width="60%"}
+::: {.column}
 Content of the right column.
 :::
 ::::::


### PR DESCRIPTION
As per issue rstudio/rmarkdown#1624 the width setting doesn't work in powerpoint. I have removed it for the moment. Hope that is ok.