### PR TITLE
update rticles chapter based on change in version 0.15

### DIFF
--- a/13-rticles.Rmd
+++ b/13-rticles.Rmd
@@ -34,11 +34,11 @@ If you are using RStudio, you can easily access the templates through `File -> N
 knitr::include_graphics("images/rticles-templates.png", dpi = NA)
 ```
 
-If you are using the command line, you can use the `rmarkdown::draft()` function, which requires you to specify a template, e.g.,
+If you are using the command line, you can use the `rmarkdown::draft()` function, which requires you to specify a template using the journal short name, e.g.,
 
 ```r
 rmarkdown::draft(
-  "MyJSSArticle.Rmd", template = "jss_article",
+  "MyJSSArticle.Rmd", template = "jss",
   package = "rticles"
 )
 ```
@@ -63,7 +63,7 @@ The **rticles** package provides templates for various journals and publishers, 
 - MDPI journal submissions
 - Springer journal submissions
 
-The full list is available within the R Markdown templates window in RStudio, or through the command `getNamespaceExports("rticles")`.
+The full list is available within the R Markdown templates window in RStudio, or through the command `rticles::journals()`.
 
 ## Using a template {#rticles-usage}
 

--- a/13-rticles.Rmd
+++ b/13-rticles.Rmd
@@ -38,8 +38,7 @@ If you are using the command line, you can use the `rmarkdown::draft()` function
 
 ```r
 rmarkdown::draft(
-  "MyJSSArticle.Rmd", template = "jss",
-  package = "rticles"
+  "MyJSSArticle.Rmd", template = "jss", package = "rticles"
 )
 ```
 
@@ -63,7 +62,11 @@ The **rticles** package provides templates for various journals and publishers, 
 - MDPI journal submissions
 - Springer journal submissions
 
-The full list is available within the R Markdown templates window in RStudio, or through the command `rticles::journals()`.
+The full list is available within the R Markdown templates window in RStudio, or through the function `rticles::journals()`:
+
+```{r}
+rticles::journals()
+```
 
 ## Using a template {#rticles-usage}
 


### PR DESCRIPTION
This follows some changes made in https://github.com/rstudio/rticles/pull/316

I just made a small change since we break the previous code in `rmarkdown::draft` but I did not yet take the time to improve this rticles chapter. 

This can be merged once **rticles** next version 0.15 has been released to CRAN. Next week for sure.



