### PR TITLE
Add an example to cross-refer `$$...$$`  equations

### DIFF
--- a/12-bookdown.Rmd
+++ b/12-bookdown.Rmd
@@ -156,6 +156,22 @@ It renders the equation below \@ref(eq:emc):
   (\#eq:emc)
 \end{equation}
 
+You can also use equation labels with `$$...$$` syntax. For example:
+
+```latex
+$$
+  E=mc^2
+  (\#eq:emc2)
+$$
+```
+
+It renders the equation below \@ref(eq:emc2):
+
+$$
+  E=mc^2
+  (\#eq:emc2)
+$$
+
 ### Theorems and proofs {#theorems}
 
 Theorems and proofs provide environments that are commonly used within articles and books in mathematics. To write a theorem, you can use the syntax below:


### PR DESCRIPTION
I assign the copyright of this contribution to the authors of the book "R Markdown: The Definitive Guide".