### PR TITLE
Adding a direct link to Pandoc's Latex varaibles

### DIFF
--- a/03-documents.Rmd
+++ b/03-documents.Rmd
@@ -873,7 +873,7 @@ geometry: margin=1in
 ---
 ```
 
-A few available metadata variables are displayed in Table \@ref(tab:latex-vars) (consult the Pandoc manual for the full list):
+A few available metadata variables are displayed in Table \@ref(tab:latex-vars) (consult the Pandoc manual for [the full list](https://pandoc.org/MANUAL.html#variables-for-latex)):
 
 Table: (\#tab:latex-vars) Available top-level YAML metadata variables for LaTeX output.
 


### PR DESCRIPTION
I added a link to [Pandoc's Latex variables](https://pandoc.org/MANUAL.html#variables-for-latex). This might save beginners like me some time when customizing PDF output.