### PR TITLE
Change name of the main branch in edit link

### DIFF
--- a/_output.yml
+++ b/_output.yml
@@ -9,7 +9,7 @@ bookdown::gitbook:
       after: |
         <li><a href="https://bookdown.org" target="_blank">Published with bookdown</a></li>
     download: [pdf]
-    edit: https://github.com/rstudio/rmarkdown-book/edit/master/%s
+    edit: https://github.com/rstudio/rmarkdown-book/edit/main/%s
     sharing:
       github: yes
       facebook: no


### PR DESCRIPTION
The current one leads to 404 on github